### PR TITLE
Fix tag styles from extensions not loading correctly

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1153,7 +1153,7 @@ export class MarkdownParser extends Parser {
         if (style) {
           if (!styles) styles = {}
           if (Array.isArray(style) || style instanceof Tag) styles[name] = style
-          else Object.assign(style, styles)
+          else Object.assign(styles, style)
         }
       }
       nodeSet = new NodeSet(nodeTypes)


### PR DESCRIPTION
I tried using the `Strikethrough` extension in a CM editor, but noticed that the strikethrough styling wasn't applying to strikethrough nodes (e.g. `~~content~~`).

This PR fixes that issue. The issue is that the directionality of `Object.assign` is (target, source), not (source, target), so the extension's tag styles weren't being added to the `styles` object correctly.