### PR TITLE
Require whitespace between markers and content in GFM task lists

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export const TaskList: MarkdownConfig = {
   parseBlock: [{
     name: "TaskList",
     leaf(cx, leaf) {
-      return /^\[[ xX]\]/.test(leaf.content) && cx.parentType().name == "ListItem" ? new TaskParser : null
+      return /^\[[ xX]\]\s+/.test(leaf.content) && cx.parentType().name == "ListItem" ? new TaskParser : null
     },
     after: "SetextHeading"
   }]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export const TaskList: MarkdownConfig = {
   parseBlock: [{
     name: "TaskList",
     leaf(cx, leaf) {
-      return /^\[[ xX]\]\s+/.test(leaf.content) && cx.parentType().name == "ListItem" ? new TaskParser : null
+      return /^\[[ xX]\][ \t]+/.test(leaf.content) && cx.parentType().name == "ListItem" ? new TaskParser : null
     },
     after: "SetextHeading"
   }]


### PR DESCRIPTION
Addresses https://github.com/lezer-parser/markdown/issues/25.