### PR TITLE
Autolink for https://www and hyphen

### DIFF
--- a/test/test-extension.ts
+++ b/test/test-extension.ts
@@ -257,4 +257,7 @@ describe("Extension", () => {
 
   test("Autolink (email .co.uk)", `
 {P:{URL:foo@bar.co.uk}}`)
+
+  test("Autolink (http://www.foo-bar.com/)", `
+{P:{URL:http://www.foo-bar.com/}}`)
 })


### PR DESCRIPTION
I noticed that when `http`, `www.` and hyphen is used in URL simultaneuously, the link isn't parsed properly.

I have written a test, but I don't want to step on your toes with impl.