### PR TITLE
Require whitespace before link titles

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1521,8 +1521,11 @@ function finishLink(cx: InlineContext, content: Element[], type: Type, start: nu
     let dest = parseURL(text, pos - cx.offset, cx.offset), title
     if (dest) {
       pos = cx.skipSpace(dest.to)
-      title = parseLinkTitle(text, pos - cx.offset, cx.offset)
-      if (title) pos = cx.skipSpace(title.to)
+      // The destination and title must be separated by whitespace
+      if (pos != dest.to) {
+        title = parseLinkTitle(text, pos - cx.offset, cx.offset)
+        if (title) pos = cx.skipSpace(title.to)
+      }
     }
     if (cx.char(pos) == 41 /* ')' */) {
       content.push(elt(Type.LinkMark, startPos, startPos + 1))


### PR DESCRIPTION
Resolves #35.

I'm not sure how to add unit tests for this (the tests are written in a DSL I still don't fully understand) but I've tested it manually and it matches the CommonMark reference implementation's output when hooked up to my HTML renderer:
![image](https://github.com/lezer-parser/markdown/assets/79560998/891664ea-82f1-446d-a7ad-01c7876a1279)
![image](https://github.com/lezer-parser/markdown/assets/79560998/cc1e85ea-e2a6-4b8f-a661-69689a7d269d)

<details>
<summary>Here's the AST after the fix; note that I'm testing it with my autolink parsing change from #34</summary>

```
(Document 0-264
    (Paragraph 0-63
        (Link 0-12
            (LinkMark 0-1)
            "Click here"
            (LinkMark 11-12)
        )
        "(http://example.com\"This link goes to example.com\")"
    )
    "\n\n"
    (Paragraph 65-129
        (Link 65-129
            (LinkMark 65-66)
            "Click here"
            (LinkMark 76-77)
            (LinkMark 77-78)
            (URL 78-96)
            " "
            (LinkTitle 97-128)
            (LinkMark 128-129)
        )
    )
    "\n\n"
    (Paragraph 131-196
        (Link 131-143
            (LinkMark 131-132)
            "Click here"
            (LinkMark 142-143)
        )
        "("
        (Autolink 144-164
            (LinkMark 144-145)
            (URL 145-163)
            (LinkMark 163-164)
        )
        "\"This link goes to example.com\")"
    )
    "\n\n"
    (Paragraph 198-264
        (Link 198-264
            (LinkMark 198-199)
            "Click here"
            (LinkMark 209-210)
            (LinkMark 210-211)
            (URL 211-231)
            " "
            (LinkTitle 232-263)
            (LinkMark 263-264)
        )
    )
)
```

</details>