### PR TITLE
Check if delimiter is an opening delimiter in `findOpeningDelimiter`

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1744,7 +1744,7 @@ export class InlineContext {
   findOpeningDelimiter(type: DelimiterType) {
     for (let i = this.parts.length - 1; i >= 0; i--) {
       let part = this.parts[i]
-      if (part instanceof InlineDelimiter && part.type == type) return i
+      if (part instanceof InlineDelimiter && part.type == type && part.side === 1) return i
     }
     return null
   }


### PR DESCRIPTION
This PR adds a check to `findOpeningDelimiter` to check if the delimiter is actually an open one.

Previously, `findOpeningDelimiter` would return a delimiter even if it was a closing one.