### PR TITLE
Add delimiterResolvers hook for custom delimiter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ parser</a>) to this parser.</p>
 </dl>
 <dl>
 <dt id="user-content-markdownextension">
-  <code>type</code>
-  <code><strong><a href="#user-content-markdownextension">MarkdownExtension</a></strong> = <a href="#user-content-markdownconfig">MarkdownConfig</a> | readonly <a href="#user-content-markdownextension">MarkdownExtension</a>[]</code>
+  <code>
+    type
+    <strong><a href="#user-content-markdownextension">MarkdownExtension</a></strong> = <a href="#user-content-markdownconfig">MarkdownConfig</a> | readonly <a href="#user-content-markdownextension">MarkdownExtension</a>[]</code>
 </dt>
 
 <dd><p>To make it possible to group extensions together into bigger
@@ -339,7 +340,9 @@ general types of block parsers:</p>
 <p>Composite block parsers, which handle things like lists and
 blockquotes. These define a <a href="#user-content-blockparser.parse"><code>parse</code></a> method
 that <a href="#user-content-blockcontext.startcomposite">starts</a> a composite block
-and returns null when it recognizes its syntax.</p>
+and returns null when it recognizes its syntax. The node type
+used by such a block must define a
+<a href="#user-content-nodespec.composite"><code>composite</code></a> function as well.</p>
 </li>
 <li>
 <p>Eager leaf block parsers, used for things like code or HTML
@@ -372,7 +375,7 @@ observe that block.</p>
 <dd><p>The eager parse function, which can look at the block's first
 line and return <code>false</code> to do nothing, <code>true</code> if it has parsed
 (and <a href="#user-content-blockcontext.nextline">moved past</a> a block), or <code>null</code> if
-it has started a composite block.</p>
+it has <a href="#user-content-blockcontext.startcomposite">started</a> a composite block.</p>
 </dd><dt id="user-content-blockparser.leaf">
   <code><strong><a href="#user-content-blockparser.leaf">leaf</a></strong>&#8288;?: fn(<a id="user-content-blockparser.leaf^cx" href="#user-content-blockparser.leaf^cx">cx</a>: <a href="#user-content-blockcontext">BlockContext</a>, <a id="user-content-blockparser.leaf^leaf" href="#user-content-blockparser.leaf^leaf">leaf</a>: <a href="#user-content-leafblock">LeafBlock</a>) → <a href="#user-content-leafblockparser">LeafBlockParser</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null">null</a></code></dt>
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ the inline content.</p>
   <code><strong><a href="#user-content-markdownconfig.parseinline">parseInline</a></strong>&#8288;?: readonly <a href="#user-content-inlineparser">InlineParser</a>[]</code></dt>
 
 <dd><p>Define new <a href="#user-content-inlineparser">inline parsing</a> logic.</p>
+</dd><dt id="user-content-markdownconfig.delimiterresolvers">
+  <code><strong><a href="#user-content-markdownconfig.delimiterresolvers">delimiterResolvers</a></strong>&#8288;?: readonly (fn(<a id="user-content-markdownconfig.delimiterresolvers^cx" href="#user-content-markdownconfig.delimiterresolvers^cx">cx</a>: <a href="#user-content-inlinecontext">InlineContext</a>))[]</code></dt>
+
+<dd><p>Define custom delimiter resolution logic.</p>
 </dd><dt id="user-content-markdownconfig.remove">
   <code><strong><a href="#user-content-markdownconfig.remove">remove</a></strong>&#8288;?: readonly <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>[]</code></dt>
 
@@ -544,7 +548,17 @@ block parsing</a>.</p>
 
 <dd><p>Inline parsing functions get access to this context, and use it to
 read the content and emit syntax nodes.</p>
-<dl><dt id="user-content-inlinecontext.parser">
+<dl><dt id="user-content-inlinecontext.parts">
+  <code><strong><a href="#user-content-inlinecontext.parts">parts</a></strong>: (<a href="#user-content-element">Element</a> | {type: <a href="#user-content-delimitertype">DelimiterType</a>, from: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, to: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, side: 0 | 1 | 2} | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null">null</a>)[]</code></dt>
+
+<dd><p>The elements and delimiters collected so far during inline
+parsing. <a href="#user-content-markdownconfig.delimiterresolvers">Delimiter resolvers</a>
+can inspect and modify this array to implement custom resolution
+logic. Delimiters are objects with <code>type</code>, <code>from</code>, <code>to</code>, and
+<code>side</code> properties (where side is 1 for opening, 2 for closing,
+or 3 for both). After resolution, only <a href="#user-content-element"><code>Element</code></a>
+objects remain.</p>
+</dd><dt id="user-content-inlinecontext.parser">
   <code><strong><a href="#user-content-inlinecontext.parser">parser</a></strong>: <a href="#user-content-markdownparser">MarkdownParser</a></code></dt>
 
 <dd><p>The parser that is being used.</p>

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ the inline content.</p>
   <code><strong><a href="#user-content-markdownconfig.parseinline">parseInline</a></strong>&#8288;?: readonly <a href="#user-content-inlineparser">InlineParser</a>[]</code></dt>
 
 <dd><p>Define new <a href="#user-content-inlineparser">inline parsing</a> logic.</p>
-</dd><dt id="user-content-markdownconfig.delimiterresolvers">
-  <code><strong><a href="#user-content-markdownconfig.delimiterresolvers">delimiterResolvers</a></strong>&#8288;?: readonly (fn(<a id="user-content-markdownconfig.delimiterresolvers^cx" href="#user-content-markdownconfig.delimiterresolvers^cx">cx</a>: <a href="#user-content-inlinecontext">InlineContext</a>))[]</code></dt>
+</dd><dt id="user-content-markdownconfig.preresolvedelimiters">
+  <code><strong><a href="#user-content-markdownconfig.preresolvedelimiters">preResolveDelimiters</a></strong>&#8288;?: readonly (fn(<a id="user-content-markdownconfig.preresolvedelimiters^ctx" href="#user-content-markdownconfig.preresolvedelimiters^ctx">ctx</a>: <a href="#user-content-preresolvecontext">PreResolveContext</a>))[]</code></dt>
 
-<dd><p>Define custom delimiter resolution logic.</p>
+<dd><p>Hooks called before standard delimiter resolution. Each hook
+receives a <a href="#user-content-preresolvecontext">PreResolveContext</a> and can
+inspect delimiters and add elements or mark delimiters as resolved.</p>
 </dd><dt id="user-content-markdownconfig.remove">
   <code><strong><a href="#user-content-markdownconfig.remove">remove</a></strong>&#8288;?: readonly <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>[]</code></dt>
 
@@ -98,6 +100,50 @@ the inline content.</p>
 
 <dd><p>Add a parse wrapper (such as a <a href="#user-content-common.parsemixed">mixed-language
 parser</a>) to this parser.</p>
+</dd></dl>
+
+</dd>
+</dl>
+<dl>
+<dt id="user-content-preresolvecontext">
+  <h4>
+    <code>interface</code>
+    <a href="#user-content-preresolvecontext">PreResolveContext</a></h4>
+</dt>
+
+<dd><p>Context object passed to pre-resolve delimiter hooks. Provides
+an immutable view of pending delimiters and methods to mark them
+as resolved or add elements.</p>
+<dl><dt id="user-content-preresolvecontext.delimiters">
+  <code><strong><a href="#user-content-preresolvecontext.delimiters">delimiters</a></strong>: readonly {type: <a href="#user-content-delimitertype">DelimiterType</a>, from: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, to: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, side: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}[]</code></dt>
+
+<dd><p>Immutable list of pending delimiters. Each delimiter has a type,
+position range (from/to), and side flags (1=open, 2=close, 3=both).</p>
+</dd><dt id="user-content-preresolvecontext.blockend">
+  <code><strong><a href="#user-content-preresolvecontext.blockend">blockEnd</a></strong>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code></dt>
+
+<dd><p>End position of the current inline section.</p>
+</dd><dt id="user-content-preresolvecontext.parser">
+  <code><strong><a href="#user-content-preresolvecontext.parser">parser</a></strong>: <a href="#user-content-markdownparser">MarkdownParser</a></code></dt>
+
+<dd><p>The parser being used.</p>
+</dd><dt id="user-content-preresolvecontext.markresolved">
+  <code><strong><a href="#user-content-preresolvecontext.markresolved">markResolved</a></strong>(<a id="user-content-preresolvecontext.markresolved^index" href="#user-content-preresolvecontext.markresolved^index">index</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code></dt>
+
+<dd><p>Mark the delimiter at the given index as resolved (it will be
+skipped by standard resolution).</p>
+</dd><dt id="user-content-preresolvecontext.addelement">
+  <code><strong><a href="#user-content-preresolvecontext.addelement">addElement</a></strong>(<a id="user-content-preresolvecontext.addelement^element" href="#user-content-preresolvecontext.addelement^element">element</a>: <a href="#user-content-element">Element</a>)</code></dt>
+
+<dd><p>Add an element to the output.</p>
+</dd><dt id="user-content-preresolvecontext.elt">
+  <code><strong><a href="#user-content-preresolvecontext.elt">elt</a></strong>(<a id="user-content-preresolvecontext.elt^type" href="#user-content-preresolvecontext.elt^type">type</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, <a id="user-content-preresolvecontext.elt^from" href="#user-content-preresolvecontext.elt^from">from</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, <a id="user-content-preresolvecontext.elt^to" href="#user-content-preresolvecontext.elt^to">to</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, <a id="user-content-preresolvecontext.elt^children" href="#user-content-preresolvecontext.elt^children">children</a>&#8288;?: readonly <a href="#user-content-element">Element</a>[]) → <a href="#user-content-element">Element</a></code></dt>
+
+<dd><p>Create an element.</p>
+</dd><dt id="user-content-preresolvecontext.slice">
+  <code><strong><a href="#user-content-preresolvecontext.slice">slice</a></strong>(<a id="user-content-preresolvecontext.slice^from" href="#user-content-preresolvecontext.slice^from">from</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, <a id="user-content-preresolvecontext.slice^to" href="#user-content-preresolvecontext.slice^to">to</a>: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>) → <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code></dt>
+
+<dd><p>Get a substring of the inline section using document-relative positions.</p>
 </dd></dl>
 
 </dd>
@@ -548,17 +594,7 @@ block parsing</a>.</p>
 
 <dd><p>Inline parsing functions get access to this context, and use it to
 read the content and emit syntax nodes.</p>
-<dl><dt id="user-content-inlinecontext.parts">
-  <code><strong><a href="#user-content-inlinecontext.parts">parts</a></strong>: (<a href="#user-content-element">Element</a> | {type: <a href="#user-content-delimitertype">DelimiterType</a>, from: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, to: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, side: 0 | 1 | 2} | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null">null</a>)[]</code></dt>
-
-<dd><p>The elements and delimiters collected so far during inline
-parsing. <a href="#user-content-markdownconfig.delimiterresolvers">Delimiter resolvers</a>
-can inspect and modify this array to implement custom resolution
-logic. Delimiters are objects with <code>type</code>, <code>from</code>, <code>to</code>, and
-<code>side</code> properties (where side is 1 for opening, 2 for closing,
-or 3 for both). After resolution, only <a href="#user-content-element"><code>Element</code></a>
-objects remain.</p>
-</dd><dt id="user-content-inlinecontext.parser">
+<dl><dt id="user-content-inlinecontext.parser">
   <code><strong><a href="#user-content-inlinecontext.parser">parser</a></strong>: <a href="#user-content-markdownparser">MarkdownParser</a></code></dt>
 
 <dd><p>The parser that is being used.</p>

--- a/src/README.md
+++ b/src/README.md
@@ -33,6 +33,8 @@ The code is licensed under an MIT license.
 
 @MarkdownConfig
 
+@PreResolveContext
+
 @MarkdownExtension
 
 @parseCode

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {parser, MarkdownParser, MarkdownConfig, MarkdownExtension,
+export {parser, MarkdownParser, MarkdownConfig, MarkdownExtension, PreResolveContext,
         NodeSpec, InlineParser, BlockParser, LeafBlockParser,
         Line, Element, LeafBlock, DelimiterType, BlockContext, InlineContext} from "./markdown"
 export {parseCode} from "./nest"

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1093,6 +1093,33 @@ export interface LeafBlockParser {
   finish(cx: BlockContext, leaf: LeafBlock): boolean
 }
 
+/// Context object passed to pre-resolve delimiter hooks. Provides
+/// an immutable view of pending delimiters and methods to mark them
+/// as resolved or add elements.
+export interface PreResolveContext {
+  /// Immutable list of pending delimiters. Each delimiter has a type,
+  /// position range (from/to), and side flags (1=open, 2=close, 3=both).
+  readonly delimiters: ReadonlyArray<{
+    readonly type: DelimiterType
+    readonly from: number
+    readonly to: number
+    readonly side: number
+  }>
+  /// End position of the current inline section.
+  readonly blockEnd: number
+  /// The parser being used.
+  readonly parser: MarkdownParser
+  /// Mark the delimiter at the given index as resolved (it will be
+  /// skipped by standard resolution).
+  markResolved(index: number): void
+  /// Add an element to the output.
+  addElement(element: Element): void
+  /// Create an element.
+  elt(type: string, from: number, to: number, children?: readonly Element[]): Element
+  /// Get a substring of the inline section using document-relative positions.
+  slice(from: number, to: number): string
+}
+
 /// Objects of this type are used to
 /// [configure](#MarkdownParser.configure) the Markdown parser.
 export interface MarkdownConfig {
@@ -1104,8 +1131,10 @@ export interface MarkdownConfig {
   parseBlock?: readonly BlockParser[]
   /// Define new [inline parsing](#InlineParser) logic.
   parseInline?: readonly InlineParser[]
-  /// Define custom delimiter resolution logic.
-  delimiterResolvers?: readonly ((cx: InlineContext) => void)[]
+  /// Hooks called before standard delimiter resolution. Each hook
+  /// receives a [PreResolveContext](#PreResolveContext) and can
+  /// inspect delimiters and add elements or mark delimiters as resolved.
+  preResolveDelimiters?: readonly ((ctx: PreResolveContext) => void)[]
   /// Remove the named parsers from the configuration.
   remove?: readonly string[]
   /// Add a parse wrapper (such as a [mixed-language
@@ -1142,7 +1171,7 @@ export class MarkdownParser extends Parser {
     /// @internal
     readonly inlineParsers: readonly (((cx: InlineContext, next: number, pos: number) => number) | undefined)[],
     /// @internal
-    readonly delimiterResolvers: readonly ((cx: InlineContext) => void)[],
+    readonly preResolveDelimiters: readonly ((ctx: PreResolveContext) => void)[],
     /// @internal
     readonly inlineNames: readonly string[],
     /// @internal
@@ -1166,7 +1195,7 @@ export class MarkdownParser extends Parser {
     let blockParsers = this.blockParsers.slice(), leafBlockParsers = this.leafBlockParsers.slice(),
         blockNames = this.blockNames.slice(), endLeafBlock = this.endLeafBlock.slice()
     let inlineParsers = this.inlineParsers.slice(), inlineNames = this.inlineNames.slice()
-    let delimiterResolvers = this.delimiterResolvers.slice()
+    let preResolveDelimiters = this.preResolveDelimiters.slice()
     let wrappers = this.wrappers
 
     if (nonEmpty(config.defineNodes)) {
@@ -1237,12 +1266,12 @@ export class MarkdownParser extends Parser {
     }
 
     if (config.wrap) wrappers = wrappers.concat(config.wrap)
-    if (config.delimiterResolvers) delimiterResolvers = delimiterResolvers.concat(config.delimiterResolvers)
+    if (config.preResolveDelimiters) preResolveDelimiters = preResolveDelimiters.concat(config.preResolveDelimiters)
 
     return new MarkdownParser(nodeSet,
                               blockParsers, leafBlockParsers, blockNames,
                               endLeafBlock, skipContextMarkup,
-                              inlineParsers, delimiterResolvers, inlineNames, wrappers)
+                              inlineParsers, preResolveDelimiters, inlineNames, wrappers)
   }
 
   /// @internal
@@ -1288,7 +1317,7 @@ function resolveConfig(spec: MarkdownExtension): MarkdownConfig | null {
     defineNodes: conc(conf.defineNodes, rest.defineNodes),
     parseBlock: conc(conf.parseBlock, rest.parseBlock),
     parseInline: conc(conf.parseInline, rest.parseInline),
-    delimiterResolvers: conc(conf.delimiterResolvers, rest.delimiterResolvers),
+    preResolveDelimiters: conc(conf.preResolveDelimiters, rest.preResolveDelimiters),
     remove: conc(conf.remove, rest.remove),
     wrap: !wrapA ? wrapB : !wrapB ? wrapA :
       (inner, input, fragments, ranges) => wrapA!(wrapB!(inner, input, fragments, ranges), input, fragments, ranges)
@@ -1640,16 +1669,86 @@ function parseLinkLabel(text: string, start: number, offset: number, requireNonW
   return null
 }
 
+// Internal implementation of PreResolveContext that wraps InlineContext
+class PreResolveContextImpl implements PreResolveContext {
+  readonly delimiters: ReadonlyArray<{
+    readonly type: DelimiterType
+    readonly from: number
+    readonly to: number
+    readonly side: number
+  }>
+  readonly blockEnd: number
+  readonly parser: MarkdownParser
+  private resolvedIndices: Set<number> = new Set()
+  private addedElements: Element[] = []
+  private cx: InlineContext
+  private delimToPartIndex: number[] = []
+
+  constructor(cx: InlineContext, from: number) {
+    this.cx = cx
+    this.parser = cx.parser
+    this.blockEnd = cx.end
+    // Build immutable list of delimiters with mapping to parts indices
+    const delims: Array<{
+      readonly type: DelimiterType
+      readonly from: number
+      readonly to: number
+      readonly side: number
+    }> = []
+    for (let i = from; i < cx.parts.length; i++) {
+      const part = cx.parts[i]
+      if (part && !(part instanceof Element)) {
+        const delim = part as InlineDelimiter
+        this.delimToPartIndex.push(i)
+        delims.push({
+          type: delim.type,
+          from: delim.from,
+          to: delim.to,
+          side: delim.side
+        })
+      }
+    }
+    this.delimiters = delims
+  }
+
+  markResolved(index: number): void {
+    if (index >= 0 && index < this.delimiters.length) {
+      this.resolvedIndices.add(index)
+    }
+  }
+
+  addElement(element: Element): void {
+    this.addedElements.push(element)
+  }
+
+  elt(type: string, from: number, to: number, children?: readonly Element[]): Element {
+    return this.cx.elt(type, from, to, children as Element[])
+  }
+
+  slice(from: number, to: number): string {
+    return this.cx.slice(from, to)
+  }
+
+  // Apply the changes back to the InlineContext
+  apply(): void {
+    // Null out resolved delimiters using the mapping
+    for (const delimIndex of this.resolvedIndices) {
+      const partIndex = this.delimToPartIndex[delimIndex]
+      if (partIndex !== undefined) {
+        this.cx.parts[partIndex] = null
+      }
+    }
+    // Add new elements to parts
+    for (const elt of this.addedElements) {
+      this.cx.parts.push(elt)
+    }
+  }
+}
+
 /// Inline parsing functions get access to this context, and use it to
 /// read the content and emit syntax nodes.
 export class InlineContext {
-  /// The elements and delimiters collected so far during inline
-  /// parsing. [Delimiter resolvers](#MarkdownConfig.delimiterResolvers)
-  /// can inspect and modify this array to implement custom resolution
-  /// logic. Delimiters are objects with `type`, `from`, `to`, and
-  /// `side` properties (where side is 1 for opening, 2 for closing,
-  /// or 3 for both). After resolution, only [`Element`](#Element)
-  /// objects remain.
+  /// @internal
   parts: (Element | InlineDelimiter | null)[] = []
 
   /// @internal
@@ -1705,7 +1804,12 @@ export class InlineContext {
   /// Resolve markers between this.parts.length and from, wrapping matched markers in the
   /// appropriate node and updating the content of this.parts. @internal
   resolveMarkers(from: number) {
-    for (let resolver of this.parser.delimiterResolvers) resolver(this)
+    // Run pre-resolve hooks with a safe context wrapper
+    if (this.parser.preResolveDelimiters.length) {
+      const ctx = new PreResolveContextImpl(this, from)
+      for (const hook of this.parser.preResolveDelimiters) hook(ctx)
+      ctx.apply()
+    }
     // Scan forward, looking for closing tokens
     for (let i = from; i < this.parts.length; i++) {
       let close = this.parts[i]

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1643,7 +1643,13 @@ function parseLinkLabel(text: string, start: number, offset: number, requireNonW
 /// Inline parsing functions get access to this context, and use it to
 /// read the content and emit syntax nodes.
 export class InlineContext {
-  /// @internal
+  /// The elements and delimiters collected so far during inline
+  /// parsing. [Delimiter resolvers](#MarkdownConfig.delimiterResolvers)
+  /// can inspect and modify this array to implement custom resolution
+  /// logic. Delimiters are objects with `type`, `from`, `to`, and
+  /// `side` properties (where side is 1 for opening, 2 for closing,
+  /// or 3 for both). After resolution, only [`Element`](#Element)
+  /// objects remain.
   parts: (Element | InlineDelimiter | null)[] = []
 
   /// @internal

--- a/test/test-delimiter-resolvers.ts
+++ b/test/test-delimiter-resolvers.ts
@@ -1,0 +1,52 @@
+import {parser as cmParser, InlineContext} from "../dist/index.js"
+import {compareTree} from "./compare-tree.js"
+import {SpecParser} from "./spec.js"
+import {it, describe} from "mocha"
+
+// A resolver that clears all asterisk emphasis delimiters (identified by checking
+// the character at their position). This demonstrates access to delimiters added
+// by the built-in Emphasis parser.
+function clearAsteriskEmphasis(cx: InlineContext) {
+  for (let i = 0; i < (cx as any).parts.length; i++) {
+    let part = (cx as any).parts[i]
+    // InlineDelimiter has type.resolve, Elements don't
+    if (part && part.type && part.type.resolve === "Emphasis") {
+      // Check if this is an asterisk delimiter by looking at the character
+      let char = cx.slice(part.from, part.from + 1)
+      if (char === "*") {
+        (cx as any).parts[i] = null
+      }
+    }
+  }
+}
+
+const NoAsteriskEmphasis = {
+  delimiterResolvers: [clearAsteriskEmphasis]
+} as any
+
+const parser = cmParser.configure([NoAsteriskEmphasis])
+const specParser = new SpecParser(parser)
+
+function test(name: string, spec: string, p = parser) {
+  it(name, () => {
+    let {tree, doc} = specParser.parse(spec, name)
+    compareTree(p.parse(doc), tree)
+  })
+}
+
+describe("delimiterResolvers", () => {
+  test("clears asterisk emphasis", `
+{P:*hello*}`)
+
+  test("clears strong asterisk emphasis", `
+{P:**hello**}`)
+
+  test("preserves underscore emphasis", `
+{P:{Em:{e:_}hello{e:_}}}`)
+
+  test("clears asterisk but preserves underscore", `
+{P:*foo* {Em:{e:_}bar{e:_}}}`)
+
+  test("clears nested asterisk in underscore", `
+{P:{Em:{e:_}hello *world*{e:_}}}`)
+})


### PR DESCRIPTION
## Summary

This adds a `delimiterResolvers` hook that lets extensions customize delimiter resolution before the standard CommonMark algorithm runs. It also makes `InlineContext.parts` public as it's required for resolvers to function.

## The Problem

Extensions that need to handle delimiters differently from CommonMark have no clean way to do it. The current `resolveMarkers` function enforces a strict tree structure: find a closer, look backward for an opener, build a node. Unmatched openers become plain text.

For my use case, I needed to:
- Extend unmatched emphasis markers to the block end (so `*hello` becomes emphasis immediately)
- Handle overlapping delimiter ranges that can't be expressed as a tree

The only way to achieve this was monkey-patching `resolveMarkers` and accessing the `@internal` `parts` array, which is fragile and breaks with updates.

I've built an extension that demonstrates this use case: [lezer-markdown-partial-emphasis](https://github.com/bxff/lezer-markdown-partial-emphasis). It creates "live" emphasis that appears as you type, using the new API.

## The Solution

Add a `delimiterResolvers` array to `MarkdownConfig`. Each resolver receives the `InlineContext` and can inspect or modify `cx.parts` before standard resolution.

```typescript
// In MarkdownConfig
delimiterResolvers?: readonly ((cx: InlineContext) => void)[]

// In resolveMarkers()
for (let resolver of this.parser.delimiterResolvers) resolver(this)
```

Resolvers can replace `InlineDelimiter` objects with `Element` objects or null them out. The standard algorithm skips already-resolved positions.

Making `parts` public is necessary for this API to work. Resolvers need to read delimiter positions, types, and side flags, then modify the array in place.

## Why This Design

I considered alternatives but they all had issues:

- **Per-delimiter resolve methods**: The main loop is "closer-driven" and can't handle unmatched openers cleanly
- **Post-process hooks**: Inefficient and can't change text already parsed as literals
- **Replace resolveMarkers entirely**: Breaks composition if multiple extensions need customization

This approach follows the existing `wrap` pattern: an array of processors that compose without conflicts. It's opt-in with zero overhead when unused.

## Testing

Added `test/test-delimiter-resolvers.ts` demonstrating the API. The test extension shows how to access and modify delimiters added by the built-in Emphasis parser (clearing asterisks while preserving underscores).

## README Changes

Regenerated the README to include documentation for the new API. This also picked up docs from an earlier commit (4d5b25c) about block context nodes and close tokens that had been missed.