### PR TITLE
Fix Nested List Table Parsing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,8 @@ class TableParser implements LeafBlockParser {
       if ((line.next == 45 || line.next == 58 || line.next == 124 /* '-:|' */) &&
           delimiterLine.test(lineText = line.text.slice(line.pos))) {
         let firstRow: Element[] = [], firstCount = parseRow(cx, leaf.content, 0, firstRow, leaf.start)
-        if (firstCount == parseRow(cx, lineText, line.pos))
+        let secondCount = parseRow(cx, lineText, 0)
+        if (firstCount == secondCount)
           this.rows = [cx.elt("TableHeader", leaf.start, leaf.start + leaf.content.length, firstRow),
                        cx.elt("TableDelimiter", cx.lineStart + line.pos, cx.lineStart + line.text.length)]
       }

--- a/test/test-extension.ts
+++ b/test/test-extension.ts
@@ -87,6 +87,14 @@ describe("Extension", () => {
 {tb:| :-: | :-: |}
 {TR:{tb:|} {TC:One} {tb:|} {TC:Two} {tb:|}}}`)
 
+  test("Tables (nested list)", `
+{BL:{LI:{l:-} {TB:{TH:{tb:|} {TC:Table} {tb:|}}
+  {tb:|:--|}}
+  {BL:{LI:{l:-} {TB:{TH:{tb:|} {TC:Table} {tb:|}}
+    {tb:|:--|}}
+    {BL:{LI:{l:-} {TB:{TH:{tb:|} {TC:Table} {tb:|}}
+      {tb:|:--|}}}}}}}}`)
+
   test("Tables (end paragraph)", `
 {P:Hello}
 {TB:{TH:{tb:|} {TC:foo} {tb:|} {TC:bar} {tb:|}}


### PR DESCRIPTION
# PR: Fix Nested List Table Parsing

## 🎯 Context

GFM tables should be parsed correctly at any nesting depth within lists.

**Example:**

```markdown
|Table|
|:--|
- |Table|
  |:--|
  - |Table|
    |:--|
    - |Table|
      |:--|
```

**Expected:** All levels parsed as tables like GitHub Flavored Markdown does.

|Table|
|:--|
- |Table|
  |:--|
  - |Table|
    |:--|
    - |Table|
      |:--|

## 🐞 The Bug (Double Offset)

In nested lists, the delimiter line was being sliced **and** then parsed using the original `line.pos`.

* **Cause:** `line.text.slice(line.pos)` + `parseRow(..., line.pos)` applied the indent offset twice.
* **Result:** At deep levels, the parser started at the trailing `|`, resulting in `0` columns and failing back to a paragraph.

## 🛠️ The Fix

Parse the sliced delimiter line from index `0` instead of `line.pos` to avoid redundant offsetting.

## 📝 Changes

* `src/extension.ts`: Update `parseRow` index to `0`.
* `test/test-extension.ts`: Added regression tests for multi-level nested tables.