### PR TITLE
Fix autolink not working with urls with a port number

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,8 +165,8 @@ export const TaskList: MarkdownConfig = {
 }
 
 const autolinkRE = /(www\.)|(https?:\/\/)|([\w.+-]{1,100}@)|(mailto:|xmpp:)/gy
-const urlRE = /[\w-]+(\.[\w-]+)+(\/[^\s<]*)?/gy
-const lastTwoDomainWords = /[\w-]+\.[\w-]+($|\/)/
+const urlRE = /[\w-]+(\.[\w-]+)+(:\d+)?(\/[^\s<]*)?/gy
+const lastTwoDomainWords = /[\w-]+\.[\w-]+($|[/:])/
 const emailRE = /[\w.+-]+@[\w-]+(\.[\w.-]+)+/gy
 const xmppResourceRE = /\/[a-zA-Z\d@.]+/gy
 


### PR DESCRIPTION
GFM supports URLs including a port number like:

- http://hoge.fuga:8080/
- https://fuga.com:8000/

This patch fixes the regex for these URLs.
